### PR TITLE
#5- logback 을 활용한 콜솔창에 sql 문 띄우기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,21 @@ repositories {
 dependencies {
 	/* Thymeleaf Layout */
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+	// log4jdbc 추가
+	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
+
 	compileOnly 'org.projectlombok:lombok'
+
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,37 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board?useUnicode=yes&characterEncoding=UTF-8&allowMultiQueries=true&serverTimezone=Asia/Seoul
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+#    url: jdbc:mysql://localhost:3306~
+    url: jdbc:log4jdbc:mysql://localhost:3306/board?useUnicode=yes&characterEncoding=UTF-8&allowMultiQueries=true&serverTimezone=Asia/Seoul
     username: root
     password: java
-    driver-class-name: com.mysql.cj.jdbc.Driver
 
 mybatis:
   type-aliases-package: com.study.board
 #  mapper.xml의 위치를 매핑시켜주는것
   mapper-locations: classpath:mybatis/mappers/**/*.xml
+
+# log4jdbc, mybatis console log
+logging:
+  level:
+    com:
+      zaxxer:
+        hikari: INFO
+    javax:
+      sql:
+        DataSource: OFF
+    jdbc:
+      audit: OFF
+      resultset: OFF
+      resultsettable: INFO  #SQL 결과 데이터 Table을 로그로 남긴다.
+      sqlonly: INFO     #SQL만 로그로 남긴다.
+      sqltiming: INFO    #SQL과 소요시간을 표기한다.
+      connection : OFF  # 커넥션 확인가능 (커넥션 누수를 해결하는데 도움이 된다.)
+    org:
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE    # 로그 레벨 : TRACE -> DEBUG -> INFO -> WARN -> ERROR -> FATAL 순서

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0


### PR DESCRIPTION
마이바티스 초기 설정을 properties로 하냐 xml 로 하냐에 따라서 방법이 다르다.

나는 초기에 yml로 설정을 햇기때문에 properties를 파일 추가해주고 yml파일에 사용자 입맛에 맞게 로깅을 설정해주면된다. 

gradle implementation 먼저 추가해야함.

웹에서 sql문을 접속할때마다 쿼리문이 콘솔창에 나오고 테이블이 표시됌.