### PR TITLE
Feature/#6 interceptor aop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 	// log4jdbc 추가
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+	// aop 추가
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'

--- a/src/main/java/com/study/board/aop/LoggerAspect.java
+++ b/src/main/java/com/study/board/aop/LoggerAspect.java
@@ -1,0 +1,28 @@
+package com.study.board.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.util.StringUtils;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggerAspect {
+    // 보드의 모든 하위 패키지 중 파라미터가 0 개 이상인 모든 메서드를 의미
+    @Around("execution(* com.study.board..*Controller.*(..)) "
+        + "|| execution(* com.study.board..*Service.*(..)) "
+        + "|| execution(* com.study.board..*Mapper.*(..))")
+    public Object printLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        String name = joinPoint.getSignature().getDeclaringTypeName();
+        String type =
+            StringUtils.contains(name, "Controller") ? "Controller ===> " :
+                StringUtils.contains(name, "Service") ? "Service ===> " :
+                    StringUtils.contains(name, "Mapper") ? "Mapper ===> " :
+                        "";
+        log.debug(type + name + ", " + joinPoint.getSignature().getName() + "()");
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/study/board/config/WebMvcConfig.java
+++ b/src/main/java/com/study/board/config/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package com.study.board.config;
+
+import com.study.board.interceptor.LoggerInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoggerInterceptor())
+            .excludePathPatterns("/css/**", "/images/**", "/js/**","/font/**");
+    }
+}

--- a/src/main/java/com/study/board/interceptor/LoggerInterceptor.java
+++ b/src/main/java/com/study/board/interceptor/LoggerInterceptor.java
@@ -1,0 +1,26 @@
+package com.study.board.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Slf4j
+public class LoggerInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
+        log.debug("==================== BEGIN ====================");
+        log.debug("Request URI ===> " + request.getRequestURI());
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+        ModelAndView modelAndView) throws Exception {
+        log.debug("==================== END ======================");
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,26 +12,6 @@ mybatis:
 #  mapper.xml의 위치를 매핑시켜주는것
   mapper-locations: classpath:mybatis/mappers/**/*.xml
 
-# log4jdbc, mybatis console log
+# log4jdbc, mybatis console log - logback-spring.xml 구성요소 추가
 logging:
-  level:
-    com:
-      zaxxer:
-        hikari: INFO
-    javax:
-      sql:
-        DataSource: OFF
-    jdbc:
-      audit: OFF
-      resultset: OFF
-      resultsettable: INFO  #SQL 결과 데이터 Table을 로그로 남긴다.
-      sqlonly: INFO     #SQL만 로그로 남긴다.
-      sqltiming: INFO    #SQL과 소요시간을 표기한다.
-      connection : OFF  # 커넥션 확인가능 (커넥션 누수를 해결하는데 도움이 된다.)
-    org:
-      hibernate:
-        SQL: DEBUG
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE    # 로그 레벨 : TRACE -> DEBUG -> INFO -> WARN -> ERROR -> FATAL 순서
+  config: classpath:logback-spring.xml

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="true">
+
+  <!-- Appenders -->
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <Pattern>%d %5p [%c] %m%n</Pattern>
+    </encoder>
+  </appender>
+
+  <appender name="console-infolog" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <Pattern>%d %5p %m%n</Pattern>
+    </encoder>
+  </appender>
+
+  <!-- Logger -->
+  <logger name="com.study" level="DEBUG" appender-ref="console" />
+  <logger name="jdbc.sqlonly" level="INFO" appender-ref="console-infolog" />
+  <logger name="jdbc.resultsettable" level="INFO" appender-ref="console-infolog" />
+
+  <!-- Root Logger -->
+  <root level="off">
+    <appender-ref ref="console" />
+  </root>
+</configuration>


### PR DESCRIPTION
this closes #10 

**Interceptor**
인터셉터는 이름 그대로 가로챈다는 의미를 가지고 있다.
인터셉터는 컨트롤러의 메서드(uri)에 접근하는 과정에서 제어가 필요할 때 사용한다.

정확하게는 컨트롤러 접근 전 후 로 나뉜다.
=>계정의 권한과 관련된 로직을 인터셉터를 사용해 더 효율적으로 처리 가능하다.

**Aop**
관점 지향 프로그래밍으로 자바의 객체지향의 성격을 더욱 돋보이게해준다.

Aop는 공통으로 처리되는 로그출력 or 보안처리 or 예외처리와 같은 코드를 별도로 분리해서 하나로 묶는 모듈화같은 개념이다.

핵심적인 관점 - 비즈니스 로직 / 부가적인 관점 - 공통처리 부분.

각각의 로직에 공통으로 처리되는 부분의 코드를 삽입하려면 공통 코드를 너무 많이 작성해야되어 코드가 복잡해지고 가독성이 떨어진다. 그래서 Aop로 한번에 묶어서 한번에 처리한다.
